### PR TITLE
Added model based implementation of language specific command data and toggle langugages for each contest

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,8 @@ To check if redis is working or not:
 2. Type `ping`
 3. If it returns `PONG`, then your redis-broker server is running fine.
 
+
+To add Language models after running SQL migrations run 
+```bash
+python manage.py loaddata --app interface language_model.json
+```

--- a/engine/script.py
+++ b/engine/script.py
@@ -47,7 +47,7 @@ def run(f, time, mem, input_file, temp_output_file, output_file, lang):
             "in_file": input_file, "temp_out_file": temp_output_file
         }
         runner = language.run_command.format(**params)
-
+        os.system(runner)
         stat = status()
         res = None
 

--- a/engine/script.py
+++ b/engine/script.py
@@ -28,10 +28,8 @@ def compare(path1, path2):
         return False
 
 
-def run(f, time, mem, input_file, temp_output_file, output_file, lang):
-    language = Programming_Language.objects.get(name=lang)
-    compilation = language.compile_command.format(f)
-    os.system(compilation)
+def compiler(compile_command):
+    os.system(compile_command)
     if (os.stat("compile_log").st_size != 0):
         with open("compile_log", "r+") as temp_file:
             return {  # Compilation Error
@@ -39,35 +37,85 @@ def run(f, time, mem, input_file, temp_output_file, output_file, lang):
                 "message": temp_file.read()
             }
     else:
-        if (language.name == "c" or language.name == "c++"):
-            runner = language.run_command.format(
-                ENGINE_PATH, time, mem, input_file, temp_output_file
-            )
-        elif (language.ext == "py"):
-            runner = language.run_command.format(
-                ENGINE_PATH, time, mem, f, input_file, temp_output_file
-            )
-        elif (language.name == "java"):
-            runner = language.run_command.format(
-                ENGINE_PATH, time, mem, os.path.abspath(OUTPATH_DIR), input_file, temp_output_file
-            )
-        os.system(runner)
-        stat = status()
-        res = None
-        if (stat['run_status'] == "OK"):
-            if (compare(output_file, temp_output_file)):
-                stat['run_status'] = "AC"
-                res = {  # Passed
-                    "code": 0,
-                    "status": stat
-                }
-            else:
-                stat['run_status'] = "WA"
-                res = {  # Failed
-                    "code": 0,
-                    "status": stat
-                }
+        return True
+
+
+def coderunner(runner, output_file, temp_output_file):
+    print(os.system(runner))
+    stat = status()
+    print(stat)
+    res = None
+    if (stat['run_status'] == "OK"):
+        if (compare(output_file, temp_output_file)):
+            stat['run_status'] = "AC"
+            res = {  # Passed
+                "code": 0,
+                "status": stat
+            }
         else:
-            res = {"code": 2, "status": stat}
-        os.remove(temp_output_file)
+            stat['run_status'] = "WA"
+            res = {  # Failed
+                "code": 0,
+                "status": stat
+            }
+    else:
+        res = {"code": 2, "status": stat}
+    os.remove(temp_output_file)
     return res
+
+
+def run_c(f, time, mem, input_file, temp_output_file, output_file):
+    language = Programming_Language.objects.get(name="c")
+    compile_stat = compiler(language.compile_command.format(f))
+    if compile_stat == True:
+        runner = language.run_command.format(
+            ENGINE_PATH, time, mem, input_file, temp_output_file
+        )
+        return coderunner(runner, output_file, temp_output_file)
+    else:
+        return compile_stat
+
+
+def run_cpp(f, time, mem, input_file, temp_output_file, output_file):
+    language = Programming_Language.objects.get(name="c++")
+    compile_stat = compiler(language.compile_command.format(f))
+    if compile_stat == True:
+        runner = language.run_command.format(
+            ENGINE_PATH, time, mem, input_file, temp_output_file
+        )
+        return coderunner(runner, output_file, temp_output_file)
+    else:
+        return compile_stat
+
+def run_python3(f, time, mem, input_file, temp_output_file, output_file):
+    language = Programming_Language.objects.get(name="python3")
+    compile_stat = compiler(language.compile_command.format(f))
+    if compile_stat == True:
+        runner = language.run_command.format(
+            ENGINE_PATH, time, mem, f, input_file, temp_output_file
+        )
+        return coderunner(runner, output_file, temp_output_file)
+    else:
+        return compile_stat
+
+def run_python2(f, time, mem, input_file, temp_output_file, output_file):
+    language = Programming_Language.objects.get(name="python2")
+    compile_stat = compiler(language.compile_command.format(f))
+    if compile_stat == True:
+        runner = language.run_command.format(
+            ENGINE_PATH, time, mem, f, input_file, temp_output_file
+        )
+        return coderunner(runner, output_file, temp_output_file)
+    else:
+        return compile_stat
+
+def run_java(f, time, mem, input_file, temp_output_file, output_file):
+    language = Programming_Language.objects.get(name="java")
+    compile_stat = compiler(language.compile_command.format(f))
+    if compile_stat == True:
+        runner = language.run_command.format(
+            ENGINE_PATH, time, mem, os.path.abspath(OUTPATH_DIR), input_file, temp_output_file
+        )
+        return coderunner(runner, output_file, temp_output_file)
+    else:
+        return compile_stat

--- a/engine/script.py
+++ b/engine/script.py
@@ -41,9 +41,7 @@ def compiler(compile_command):
 
 
 def coderunner(runner, output_file, temp_output_file):
-    print(os.system(runner))
     stat = status()
-    print(stat)
     res = None
     if (stat['run_status'] == "OK"):
         if (compare(output_file, temp_output_file)):

--- a/interface/admin.py
+++ b/interface/admin.py
@@ -12,6 +12,7 @@ admin.site.register(Contest, ContestAdmin)
 
 class TestCaseInline(admin.TabularInline):
     model = Testcases
+    fields = ['input_test', 'output_test']
     extra = 1
 
 class QuestionAdmin(admin.ModelAdmin): 
@@ -32,6 +33,7 @@ admin.site.register(Editorial, EditorialAdmin)
 class TestcaseAdmin(admin.ModelAdmin): 
     list_display = ('question',) 
     list_filter = ('question',)
+    readonly_fields = ['output_hash', 'input_hash']
 
 admin.site.register(Testcases, TestcaseAdmin)
 

--- a/interface/admin.py
+++ b/interface/admin.py
@@ -3,6 +3,8 @@ from interface.models import *
 
 admin.site.site_header = 'Online Judge GLUG'
 
+admin.site.register(Programming_Language)
+
 class ContestAdmin(admin.ModelAdmin): 
     list_display = ('contest_name', 'start_time', 'end_time') 
 

--- a/interface/models.py
+++ b/interface/models.py
@@ -24,6 +24,7 @@ class Programming_Language(models.Model):
     ext = models.CharField(max_length=16)
     compile_command = models.CharField(max_length=255)
     run_command = models.CharField(max_length=255)
+    multiplier_name = models.CharField(max_length=64)
 
     def __str__(self):
         return self.name 
@@ -69,15 +70,6 @@ class Question(models.Model):
 
     def __str__(self):
         return self.question_code
-
-    def c_cpp_lim(self):
-        return [self.c_cpp_multiplier * self.time_limit, self.c_cpp_multiplier * self.mem_limit]
-
-    def python_lim(self):
-        return [self.python_multiplier * self.time_limit, self.python_multiplier * self.mem_limit]
-
-    def java_lim(self):
-        return [self.java_multipler * self.time_limit, self.java_multipler * self.mem_limit]
 
     def save(self, *args, **kwargs):
         super(Question, self).save(*args, **kwargs)

--- a/interface/models.py
+++ b/interface/models.py
@@ -18,6 +18,16 @@ class Config(models.Model):
         return "Server wide config for start and end time"
 
 
+class Programming_Language(models.Model):
+    name = models.CharField(max_length=16)
+    ext = models.CharField(max_length=16)
+    compile_command = models.CharField(max_length=255)
+    run_command = models.CharField(max_length=255)
+
+    def __str__(self):
+        return self.name 
+
+
 class Contest(models.Model):
     contest_name = models.TextField(help_text="Name of Contest", blank=True)
     contest_code = models.TextField(blank=True, help_text="Code for Contest")
@@ -27,6 +37,7 @@ class Contest(models.Model):
     min_score = models.IntegerField(default=1, help_text="Add the fraction multiplier to question score Eg. 3 for 1/3")
     start_time = models.DateTimeField(default=t.now, help_text="Start time for contest")
     end_time = models.DateTimeField(default=t.now, help_text="End time for contest")
+    contest_langs = models.ManyToManyField(Programming_Language)
 
     def __str__(self):
         return self.contest_name + " " + self.contest_code

--- a/interface/serializers.py
+++ b/interface/serializers.py
@@ -18,9 +18,17 @@ class QuestionListSerializer(serializers.BaseSerializer):
 
 
 class ContestSerializer(serializers.ModelSerializer):
+    languages = serializers.SerializerMethodField('get_langs')
+    
+    def get_langs(self, obj):
+        langs = []
+        for each in obj.contest_langs.all():
+            langs.append(each.name)
+        return langs
+            
     class Meta:
         model = Contest
-        fields = ('contest_name', 'contest_code', 'start_time', 'end_time', 'contest_image')
+        fields = ('contest_name', 'contest_code', 'start_time', 'end_time', 'contest_image', 'languages')
 
     def to_representation(self, instance):
         data = super(ContestSerializer, self).to_representation(instance)

--- a/interface/tasks.py
+++ b/interface/tasks.py
@@ -46,7 +46,7 @@ def execute(question, coder, code, lang, contest):
         f = os.path.join(OUTPATH_DIR, filename)
         temp_output_file = os.path.join(OUTPATH_DIR, execute.request.id.__str__() + ".txt")
         net_res = []
-        multiplier = getattr(question, language.multiplier) 
+        multiplier = getattr(question, language.multiplier_name) 
         time, mem = question.time_limit*multiplier, question.mem_limit*multiplier
 
         for tests in testcases:

--- a/interface/tasks.py
+++ b/interface/tasks.py
@@ -122,9 +122,11 @@ def execute(question, coder, code, lang, contest):
                 elif (result['code'] == 0 and result['status']['run_status'] == "WA"):
                     wa += 1
             db_store(question, user, net_res, ac, wa, execute.request.id.__str__(), contest, code, lang)
+        
+        os.remove(f)
     
     except Programming_Language.DoesNotExist:
         result = {"code": 3, "message": "Language not supported"}
         db_store(question, user, result, ac, wa, execute.request.id.__str__(), contest, code, lang)
     
-    os.remove(f)
+    

--- a/interface/tasks.py
+++ b/interface/tasks.py
@@ -48,7 +48,7 @@ def execute(question, coder, code, lang, contest):
         time, mem = 0, 0
         net_res = []
         
-        if (ext == "c" or ext == "c++"):
+        if (ext == "c" or ext == "cpp"):
             time, mem = question.c_cpp_lim()
         elif (ext == "py"):
             time, mem = question.python_lim()

--- a/interface/tasks.py
+++ b/interface/tasks.py
@@ -45,15 +45,9 @@ def execute(question, coder, code, lang, contest):
         
         f = os.path.join(OUTPATH_DIR, filename)
         temp_output_file = os.path.join(OUTPATH_DIR, execute.request.id.__str__() + ".txt")
-        time, mem = 0, 0
         net_res = []
-        
-        if (ext == "c" or ext == "cpp"):
-            time, mem = question.c_cpp_lim()
-        elif (ext == "py"):
-            time, mem = question.python_lim()
-        elif (ext == "java"):
-            time, mem = question.java_lim()
+        multiplier = getattr(question, language.multiplier) 
+        time, mem = question.time_limit*multiplier, question.mem_limit*multiplier
 
         for tests in testcases:
             result = script.run(

--- a/interface/tasks.py
+++ b/interface/tasks.py
@@ -48,81 +48,26 @@ def execute(question, coder, code, lang, contest):
         time, mem = 0, 0
         net_res = []
         
-        if (ext == "c"):
-            for tests in testcases:
-                result = script.run_c(
-                    f, question.c_cpp_lim()[0], question.c_cpp_lim()[1], tests.input_path(),
-                    temp_output_file, tests.output_path()
-                )
-                net_res.append(result)
-                if (result['code'] == 1):
-                    break
-                elif (result['code'] == 0 and result['status']['run_status'] == "AC"):
-                    ac += 1
-                elif (result['code'] == 0 and result['status']['run_status'] == "WA"):
-                    wa += 1
-            db_store(question, user, net_res, ac, wa, execute.request.id.__str__(), contest, code, lang)
-        
-        elif (ext == "cpp"):
-            for tests in testcases:
-                result = script.run_cpp(
-                    f, question.c_cpp_lim()[0], question.c_cpp_lim()[1], tests.input_path(),
-                    temp_output_file, tests.output_path()
-                )
-                net_res.append(result)
-                if (result['code'] == 1):
-                    break
-                elif (result['code'] == 0 and result['status']['run_status'] == "AC"):
-                    ac += 1
-                elif (result['code'] == 0 and result['status']['run_status'] == "WA"):
-                    wa += 1
-            db_store(question, user, net_res, ac, wa, execute.request.id.__str__(), contest, code, lang)
-            
-        elif (ext == "py" and lang == "python3"):
-            for tests in testcases:
-                result = script.run_python3(
-                    f, question.python_lim()[0], question.python_lim()[1], tests.input_path(),
-                    temp_output_file, tests.output_path()
-                )
-                net_res.append(result)
-                if (result['code'] == 1):
-                    break
-                elif (result['code'] == 0 and result['status']['run_status'] == "AC"):
-                    ac += 1
-                elif (result['code'] == 0 and result['status']['run_status'] == "WA"):
-                    wa += 1
-            db_store(question, user, net_res, ac, wa, execute.request.id.__str__(), contest, code, lang)
-        
-        elif (ext == "py" and lang == "python2"):
-            for tests in testcases:
-                result = script.run_python2(
-                    f, question.python_lim()[0], question.python_lim()[1], tests.input_path(),
-                    temp_output_file, tests.output_path()
-                )
-                net_res.append(result)
-                if (result['code'] == 1):
-                    break
-                elif (result['code'] == 0 and result['status']['run_status'] == "AC"):
-                    ac += 1
-                elif (result['code'] == 0 and result['status']['run_status'] == "WA"):
-                    wa += 1
-            db_store(question, user, net_res, ac, wa, execute.request.id.__str__(), contest, code, lang)
-        
+        if (ext == "c" or ext == "c++"):
+            time, mem = question.c_cpp_lim()
+        elif (ext == "py"):
+            time, mem = question.python_lim()
         elif (ext == "java"):
-            for tests in testcases:
-                result = script.run_java(
-                    f, question.java_lim()[0], question.java_lim()[1], tests.input_path(),
-                    temp_output_file, tests.output_path()
-                )
-                net_res.append(result)
-                if (result['code'] == 1):
-                    break
-                elif (result['code'] == 0 and result['status']['run_status'] == "AC"):
-                    ac += 1
-                elif (result['code'] == 0 and result['status']['run_status'] == "WA"):
-                    wa += 1
-            db_store(question, user, net_res, ac, wa, execute.request.id.__str__(), contest, code, lang)
-        
+            time, mem = question.java_lim()
+
+        for tests in testcases:
+            result = script.run(
+                f, time, mem, tests.input_path(), temp_output_file, tests.output_path(), lang
+            )
+            net_res.append(result)
+            if (result['code'] == 1):
+                break
+            elif (result['code'] == 0 and result['status']['run_status'] == "AC"):
+                ac += 1
+            elif (result['code'] == 0 and result['status']['run_status'] == "WA"):
+                wa += 1
+        db_store(question, user, net_res, ac, wa, execute.request.id.__str__(), contest, code, lang)
+
         os.remove(f)
     
     except Programming_Language.DoesNotExist:

--- a/language_model.json
+++ b/language_model.json
@@ -1,0 +1,52 @@
+[
+    {
+        "model": "interface.programming_language", 
+        "pk": 1, 
+        "fields": {
+            "name": "c", 
+            "ext": "c", 
+            "compile_command": "gcc -Wno-deprecated {} -o compiled_code 2> compile_log", 
+            "run_command": "sudo {} --cpu {} --mem {} --usage usage.txt --exec compiled_code < {} > {}"
+        }
+    }, 
+    {
+        "model": "interface.programming_language", 
+        "pk": 2, 
+        "fields": {
+            "name": "c++", 
+            "ext": "cpp", 
+            "compile_command": "g++ -o compiled_code {} 2> compile_log", 
+            "run_command": "sudo {} --cpu {} --mem {} --usage usage.txt --exec compiled_code < {} > {}"
+        }
+    }, 
+    {
+        "model": "interface.programming_language", 
+        "pk": 3, 
+        "fields": {
+            "name": "java", 
+            "ext": "java", 
+            "compile_command": "javac {} 2> compile_log", 
+            "run_command": "sudo {} --cpu {} --mem {} --nproc 20 --usage usage.txt --exec /usr/bin/java -cp {} test < {} > {}"
+        }
+    }, 
+    {
+        "model": "interface.programming_language", 
+        "pk": 4, 
+        "fields": {
+            "name": "python2", 
+            "ext": "py", 
+            "compile_command": "python2 -m py_compile {} 2> compile_log", 
+            "run_command": "sudo {} --cpu {} --mem {} --usage usage.txt --exec /usr/bin/python2 {} < {} > {}"
+        }
+    }, 
+    {
+        "model": "interface.programming_language", 
+        "pk": 5, 
+        "fields": {
+            "name": "python3", 
+            "ext": "py", 
+            "compile_command": "python3 -m py_compile {} 2> compile_log", 
+            "run_command": "sudo {} --cpu {} --mem {} --usage usage.txt --exec /usr/bin/python3 {} < {} > {}"
+        }
+    }
+]

--- a/language_model.json
+++ b/language_model.json
@@ -6,7 +6,7 @@
             "name": "c", 
             "ext": "c", 
             "compile_command": "gcc -Wno-deprecated {} -o compiled_code 2> compile_log", 
-            "run_command": "sudo {} --cpu {} --mem {} --usage usage.txt --exec compiled_code < {} > {}"
+            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec compiled_code < {in_file} > {temp_out_file}"
         }
     }, 
     {
@@ -16,7 +16,7 @@
             "name": "c++", 
             "ext": "cpp", 
             "compile_command": "g++ -o compiled_code {} 2> compile_log", 
-            "run_command": "sudo {} --cpu {} --mem {} --usage usage.txt --exec compiled_code < {} > {}"
+            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec compiled_code < {in_file} > {temp_out_file}"
         }
     }, 
     {
@@ -26,7 +26,7 @@
             "name": "java", 
             "ext": "java", 
             "compile_command": "javac {} 2> compile_log", 
-            "run_command": "sudo {} --cpu {} --mem {} --nproc 20 --usage usage.txt --exec /usr/bin/java -cp {} test < {} > {}"
+            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --nproc 20 --usage usage.txt --exec /usr/bin/java -cp {outpath} test < {in_file} > {temp_out_file}"
         }
     }, 
     {
@@ -36,7 +36,7 @@
             "name": "python2", 
             "ext": "py", 
             "compile_command": "python2 -m py_compile {} 2> compile_log", 
-            "run_command": "sudo {} --cpu {} --mem {} --usage usage.txt --exec /usr/bin/python2 {} < {} > {}"
+            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec /usr/bin/python2 {f} < {in_file} > {temp_out_file}"
         }
     }, 
     {
@@ -46,7 +46,7 @@
             "name": "python3", 
             "ext": "py", 
             "compile_command": "python3 -m py_compile {} 2> compile_log", 
-            "run_command": "sudo {} --cpu {} --mem {} --usage usage.txt --exec /usr/bin/python3 {} < {} > {}"
+            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec /usr/bin/python3 {f} < {in_file} > {temp_out_file}"
         }
     }
 ]

--- a/language_model.json
+++ b/language_model.json
@@ -1,52 +1,56 @@
 [
     {
-        "model": "interface.programming_language", 
-        "pk": 1, 
+        "model": "interface.programming_language", "pk": 1, 
         "fields": {
-            "name": "c", 
-            "ext": "c", 
-            "compile_command": "gcc -Wno-deprecated {} -o compiled_code 2> compile_log", 
-            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec compiled_code < {in_file} > {temp_out_file}"
-        }
-    }, 
-    {
-        "model": "interface.programming_language", 
-        "pk": 2, 
-        "fields": {
-            "name": "c++", 
-            "ext": "cpp", 
-            "compile_command": "g++ -o compiled_code {} 2> compile_log", 
-            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec compiled_code < {in_file} > {temp_out_file}"
-        }
-    }, 
-    {
-        "model": "interface.programming_language", 
-        "pk": 3, 
-        "fields": {
-            "name": "java", 
-            "ext": "java", 
-            "compile_command": "javac {} 2> compile_log", 
-            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --nproc 20 --usage usage.txt --exec /usr/bin/java -cp {outpath} test < {in_file} > {temp_out_file}"
-        }
-    }, 
-    {
-        "model": "interface.programming_language", 
-        "pk": 4, 
-        "fields": {
-            "name": "python2", 
-            "ext": "py", 
-            "compile_command": "python2 -m py_compile {} 2> compile_log", 
-            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec /usr/bin/python2 {f} < {in_file} > {temp_out_file}"
-        }
-    }, 
-    {
-        "model": "interface.programming_language", 
-        "pk": 5, 
-        "fields": {
-            "name": "python3", 
-            "ext": "py", 
-            "compile_command": "python3 -m py_compile {} 2> compile_log", 
-            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec /usr/bin/python3 {f} < {in_file} > {temp_out_file}"
-        }
+            "name": "c",
+            "ext": "c",
+            "compile_command": "gcc -Wno-deprecated {} -o compiled_code 2> compile_log",
+            "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec compiled_code < {in_file} > {temp_out_file}",
+            "multiplier_name": "c_cpp_multiplier"
+            }
+        },
+        {
+            "model": "interface.programming_language", 
+            "pk": 2, 
+            "fields": {
+                "name": "c++",
+                "ext": "cpp",
+                "compile_command": "g++ -o compiled_code {} 2> compile_log",
+                "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec compiled_code < {in_file} > {temp_out_file}",
+                "multiplier_name": "c_cpp_multiplier"
+            }
+        },
+        {
+            "model": "interface.programming_language", 
+            "pk": 3, 
+            "fields": {
+                "name": "java",
+                "ext": "java",
+                "compile_command": "javac {} 2> compile_log",
+                "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --nproc 20 --usage usage.txt --exec /usr/bin/java -cp {outpath} test < {in_file} > {temp_out_file}", 
+                "multiplier_name": "java_multipler"
+            }
+        }, 
+        {
+            "model": "interface.programming_language", 
+            "pk": 4, 
+            "fields": {
+                "name": "python2",
+                "ext": "py",
+                "compile_command": "python2 -m py_compile {} 2> compile_log", 
+                "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec /usr/bin/python2 {f} < {in_file} > {temp_out_file}", 
+                "multiplier_name": "python_multiplier"
+            }
+        }, 
+        {
+            "model": "interface.programming_language", 
+            "pk": 5, 
+            "fields": {
+                "name": "python3", 
+                "ext": "py", 
+                "compile_command": "python3 -m py_compile {} 2> compile_log", 
+                "run_command": "sudo {engine_path} --cpu {time} --mem {mem} --usage usage.txt --exec /usr/bin/python3 {f} < {in_file} > {temp_out_file}", 
+                "multiplier_name": "python_multiplier"
+            }
     }
 ]


### PR DESCRIPTION
Need to add following Programming_Language models for current functionality:

C:
compile command -  gcc -Wno-deprecated {} -o compiled_code 2> compile_log
run command - sudo {} --cpu {} --mem {} --usage usage.txt --exec compiled_code < {} > {}

C++:
compile - g++ -o compiled_code {} 2> compile_log
run - sudo {} --cpu {} --mem {} --usage usage.txt --exec compiled_code < {} > {}

Java:
compile - javac {} 2> compile_log
run - sudo {} --cpu {} --mem {} --nproc 20 --usage usage.txt --exec /usr/bin/java -cp {} test < {} > {}

Python2:
compile - python2 -m py_compile {} 2> compile_log
run - sudo {} --cpu {} --mem {} --usage usage.txt --exec /usr/bin/python2 {} < {} > {}

Python3:
compile - python3 -m py_compile {} 2> compile_log
run - sudo {} --cpu {} --mem {} --usage usage.txt --exec /usr/bin/python3 {} < {} > {}